### PR TITLE
PNG_COLOR_TYPE_PALETTE support for inspect and qrtest.

### DIFF
--- a/tests/dbgutil.c
+++ b/tests/dbgutil.c
@@ -228,7 +228,11 @@ int load_png(struct quirc *q, const char *filename)
 	if (color_type & PNG_COLOR_MASK_ALPHA)
 		png_set_strip_alpha(png_ptr);
 
-	if (color_type == PNG_COLOR_TYPE_RGB ||
+	if (color_type == PNG_COLOR_TYPE_PALETTE)
+		png_set_palette_to_rgb(png_ptr);
+
+	if (color_type == PNG_COLOR_TYPE_PALETTE ||
+	    color_type == PNG_COLOR_TYPE_RGB ||
 	    color_type == PNG_COLOR_TYPE_RGB_ALPHA) {
 		png_set_rgb_to_gray_fixed(png_ptr, 1, -1, -1);
 	}


### PR DESCRIPTION
support for PNG files using palette, like this one:

![palette example](https://cloud.githubusercontent.com/assets/109415/16942902/0e9353be-4d99-11e6-9d44-b7c68cb62afb.png)
