### PR TITLE
dump_data: display a human readable Data type.

### DIFF
--- a/tests/dbgutil.c
+++ b/tests/dbgutil.c
@@ -21,14 +21,24 @@
 #include <jpeglib.h>
 #include <png.h>
 
+#include <quirc.h>
+
 #include "dbgutil.h"
 
 void dump_data(const struct quirc_data *data)
 {
+	static const char *data_type_str[] = {
+		[QUIRC_DATA_TYPE_NUMERIC] = "NUMERIC",
+		[QUIRC_DATA_TYPE_ALPHA]   = "ALPHANUMERIC",
+		[QUIRC_DATA_TYPE_BYTE]    = "BINARY",
+		[QUIRC_DATA_TYPE_KANJI]   = "KANJI",
+	};
+
 	printf("    Version: %d\n", data->version);
 	printf("    ECC level: %c\n", "MLHQ"[data->ecc_level]);
 	printf("    Mask: %d\n", data->mask);
-	printf("    Data type: %d\n", data->data_type);
+	printf("    Data type: %d (%s)\n",
+	    data->data_type, data_type_str[data->data_type]);
 	printf("    Length: %d\n", data->payload_len);
 	printf("    Payload: %s\n", data->payload);
 }


### PR DESCRIPTION
Show a human readable Data type description, before:
```
  Decode successful:
    Version: 1
    ECC level: L
    Mask: 2
    Data type: 4
    Length: 5
    Payload: plouf
```
after
```
  Decode successful:
    Version: 1
    ECC level: L
    Mask: 2
    Data type: 4 (BINARY)
    Length: 5
    Payload: plouf
```