### PR TITLE
Fix V4L2 includes on OpenBSD

### DIFF
--- a/demo/camera.c
+++ b/demo/camera.c
@@ -23,7 +23,11 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#ifdef __OpenBSD__
+#include <sys/videoio.h>
+#else
 #include <linux/videodev2.h>
+#endif
 #include "camera.h"
 
 /************************************************************************


### PR DESCRIPTION
In OpenBSD *video4linux2* API is available in `<sys/videoio.h>` header, not in `<linux/videodev2.h>` as in Linux or FreeBSD.  Detection relies on `__OpenBSD__` macro, which shouldn't be defined on other platforms.