### PR TITLE
Replaced remaining instance of png_infopp_NULL

### DIFF
--- a/tests/dbgutil.c
+++ b/tests/dbgutil.c
@@ -286,7 +286,7 @@ out:
 		if (info_ptr)
 			png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
 		else
-			png_destroy_read_struct(&png_ptr, png_infopp_NULL, (png_infopp)NULL);
+			png_destroy_read_struct(&png_ptr, (png_infopp)NULL, (png_infopp)NULL);
 	}
 	if (infile)
 		fclose(infile);


### PR DESCRIPTION
Forgot one instance of `png_infopp_NULL`.  This should have been part of 176ba28362bc0a84a052306f677bb4af91a0fa72 (PR #12).