### PR TITLE
Make Makefile compatible with BSD make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ quirc-scanner
 qrtest
 inspect
 libquirc.a
-libquirc.so
+libquirc.so*
 .*.swp
 *~

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ SDL_CFLAGS != pkg-config --cflags sdl
 SDL_LIBS != pkg-config --libs sdl
 
 LIB_VERSION = 1.0
-LIB_SONAME = libquirc.so.1
 
 QUIRC_CFLAGS = -O3 -Wall -Ilib $(CFLAGS) $(SDL_CFLAGS)
 LIB_OBJ = \
@@ -53,27 +52,26 @@ libquirc.a: $(LIB_OBJ)
 	ar cru $@ $^
 	ranlib $@
 
-libquirc.so: $(LIB_OBJ)
-	$(CC) -shared -Wl,-soname=$(LIB_SONAME) -o $@ $^ -lm
+.PHONY: libquirc.so
+libquirc.so: libquirc.so.$(LIB_VERSION)
+
+libquirc.so.$(LIB_VERSION): $(LIB_OBJ)
+	$(CC) -shared -o $@ $^ -lm
 
 %.o: %.c
 	$(CC) -fPIC $(QUIRC_CFLAGS) -o $*.o -c $*.c
 
-install: libquirc.a libquirc.so quirc-demo quirc-scanner
+install: libquirc.a libquirc.so.$(LIB_VERSION) quirc-demo quirc-scanner
 	install -o root -g root -m 0644 lib/quirc.h $(DESTDIR)$(PREFIX)/include
 	install -o root -g root -m 0644 libquirc.a $(DESTDIR)$(PREFIX)/lib
-	install -o root -g root -m 0755 libquirc.so \
-		$(DESTDIR)$(PREFIX)/lib/libquirc.so.$(LIB_VERSION)
-	ln -sf libquirc.so.$(LIB_VERSION) $(DESTDIR)$(PREFIX)/lib/$(LIB_SONAME)
-	ln -sf libquirc.so.$(LIB_VERSION) $(DESTDIR)$(PREFIX)/lib/libquirc.so
+	install -o root -g root -m 0755 libquirc.so.$(LIB_VERSION) \
+		$(DESTDIR)$(PREFIX)/lib
 	install -o root -g root -m 0755 quirc-demo $(DESTDIR)$(PREFIX)/bin
 	install -o root -g root -m 0755 quirc-scanner $(DESTDIR)$(PREFIX)/bin
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/include/quirc.h
 	rm -f $(DESTDIR)$(PREFIX)/lib/libquirc.so.$(LIB_VERSION)
-	rm -f $(DESTDIR)$(PREFIX)/lib/$(LIB_SONAME)
-	rm -f $(DESTDIR)$(PREFIX)/lib/libquirc.so
 	rm -f $(DESTDIR)$(PREFIX)/lib/libquirc.a
 	rm -f $(DESTDIR)$(PREFIX)/bin/quirc-demo
 	rm -f $(DESTDIR)$(PREFIX)/bin/quirc-scanner
@@ -82,7 +80,7 @@ clean:
 	rm -f */*.o
 	rm -f */*.lo
 	rm -f libquirc.a
-	rm -f libquirc.so
+	rm -f libquirc.so.$(LIB_VERSION)
 	rm -f qrtest
 	rm -f inspect
 	rm -f quirc-demo

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ SDL_LIBS != pkg-config --libs sdl
 
 LIB_VERSION = 1.0
 
-QUIRC_CFLAGS = -O3 -Wall -Ilib $(CFLAGS) $(SDL_CFLAGS)
+CFLAGS ?= -O3 -Wall
+QUIRC_CFLAGS = -Ilib $(CFLAGS) $(SDL_CFLAGS)
 LIB_OBJ = \
     lib/decode.o \
     lib/identify.o \

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 
 CC ?= gcc
 PREFIX ?= /usr/local
-SDL_CFLAGS := $(shell pkg-config --cflags sdl)
-SDL_LIBS := $(shell pkg-config --libs sdl)
+SDL_CFLAGS != pkg-config --cflags sdl
+SDL_LIBS != pkg-config --libs sdl
 
 LIB_VERSION = 1.0
 LIB_SONAME = libquirc.so.1

--- a/Makefile
+++ b/Makefile
@@ -37,27 +37,27 @@ DEMO_OBJ = \
 all: libquirc.so qrtest inspect quirc-demo quirc-scanner
 
 qrtest: tests/dbgutil.o tests/qrtest.o libquirc.a
-	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg -lpng
+	$(CC) -o $@ tests/dbgutil.o tests/qrtest.o libquirc.a $(LDFLAGS) -lm -ljpeg -lpng
 
 inspect: tests/dbgutil.o tests/inspect.o libquirc.a
-	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg -lpng $(SDL_LIBS) -lSDL_gfx
+	$(CC) -o $@ tests/dbgutil.o tests/inspect.o libquirc.a $(LDFLAGS) -lm -ljpeg -lpng $(SDL_LIBS) -lSDL_gfx
 
 quirc-demo: $(DEMO_OBJ) demo/demo.o libquirc.a
-	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg $(SDL_LIBS) -lSDL_gfx
+	$(CC) -o $@ $(DEMO_OBJ) demo/demo.o libquirc.a $(LDFLAGS) -lm -ljpeg $(SDL_LIBS) -lSDL_gfx
 
 quirc-scanner: $(DEMO_OBJ) demo/scanner.o libquirc.a
-	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg
+	$(CC) -o $@ $(DEMO_OBJ) demo/scanner.o libquirc.a $(LDFLAGS) -lm -ljpeg
 
 libquirc.a: $(LIB_OBJ)
 	rm -f $@
-	ar cru $@ $^
+	ar cru $@ $(LIB_OBJ)
 	ranlib $@
 
 .PHONY: libquirc.so
 libquirc.so: libquirc.so.$(LIB_VERSION)
 
 libquirc.so.$(LIB_VERSION): $(LIB_OBJ)
-	$(CC) -shared -o $@ $^ $(LDFLAGS) -lm
+	$(CC) -shared -o $@ $(LIB_OBJ) $(LDFLAGS) -lm
 
 .c.o:
 	$(CC) -fPIC $(QUIRC_CFLAGS) -o $@ -c $<

--- a/Makefile
+++ b/Makefile
@@ -37,16 +37,16 @@ DEMO_OBJ = \
 all: libquirc.so qrtest inspect quirc-demo quirc-scanner
 
 qrtest: tests/dbgutil.o tests/qrtest.o libquirc.a
-	$(CC) -o $@ $^ -lm -ljpeg -lpng
+	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg -lpng
 
 inspect: tests/dbgutil.o tests/inspect.o libquirc.a
-	$(CC) -o $@ $^ -lm -ljpeg -lpng $(SDL_LIBS) -lSDL_gfx
+	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg -lpng $(SDL_LIBS) -lSDL_gfx
 
 quirc-demo: $(DEMO_OBJ) demo/demo.o libquirc.a
-	$(CC) -o $@ $^ -lm -ljpeg $(SDL_LIBS) -lSDL_gfx
+	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg $(SDL_LIBS) -lSDL_gfx
 
 quirc-scanner: $(DEMO_OBJ) demo/scanner.o libquirc.a
-	$(CC) -o $@ $^ -lm -ljpeg
+	$(CC) -o $@ $^ $(LDFLAGS) -lm -ljpeg
 
 libquirc.a: $(LIB_OBJ)
 	rm -f $@
@@ -57,7 +57,7 @@ libquirc.a: $(LIB_OBJ)
 libquirc.so: libquirc.so.$(LIB_VERSION)
 
 libquirc.so.$(LIB_VERSION): $(LIB_OBJ)
-	$(CC) -shared -o $@ $^ -lm
+	$(CC) -shared -o $@ $^ $(LDFLAGS) -lm
 
 %.o: %.c
 	$(CC) -fPIC $(QUIRC_CFLAGS) -o $*.o -c $*.c

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SDL_LIBS != pkg-config --libs sdl
 
 LIB_VERSION = 1.0
 
-CFLAGS ?= -O3 -Wall
+CFLAGS ?= -O3 -Wall -fPIC
 QUIRC_CFLAGS = -Ilib $(CFLAGS) $(SDL_CFLAGS)
 LIB_OBJ = \
     lib/decode.o \
@@ -60,7 +60,7 @@ libquirc.so.$(LIB_VERSION): $(LIB_OBJ)
 	$(CC) -shared -o $@ $(LIB_OBJ) $(LDFLAGS) -lm
 
 .c.o:
-	$(CC) -fPIC $(QUIRC_CFLAGS) -o $@ -c $<
+	$(CC) $(QUIRC_CFLAGS) -o $@ -c $<
 
 install: libquirc.a libquirc.so.$(LIB_VERSION) quirc-demo quirc-scanner
 	install -o root -g root -m 0644 lib/quirc.h $(DESTDIR)$(PREFIX)/include

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ libquirc.so: libquirc.so.$(LIB_VERSION)
 libquirc.so.$(LIB_VERSION): $(LIB_OBJ)
 	$(CC) -shared -o $@ $^ $(LDFLAGS) -lm
 
-%.o: %.c
-	$(CC) -fPIC $(QUIRC_CFLAGS) -o $*.o -c $*.c
+.c.o:
+	$(CC) -fPIC $(QUIRC_CFLAGS) -o $@ -c $<
 
 install: libquirc.a libquirc.so.$(LIB_VERSION) quirc-demo quirc-scanner
 	install -o root -g root -m 0644 lib/quirc.h $(DESTDIR)$(PREFIX)/include

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ LIB_OBJ = \
     lib/identify.o \
     lib/quirc.o \
     lib/version_db.o
-LIB_SOBJ = $(subst .o,.lo,$(LIB_OBJ))
 DEMO_OBJ = \
     demo/camera.o \
     demo/mjpeg.o \
@@ -54,14 +53,11 @@ libquirc.a: $(LIB_OBJ)
 	ar cru $@ $^
 	ranlib $@
 
-libquirc.so: $(LIB_SOBJ)
+libquirc.so: $(LIB_OBJ)
 	$(CC) -shared -Wl,-soname=$(LIB_SONAME) -o $@ $^ -lm
 
 %.o: %.c
-	$(CC) $(QUIRC_CFLAGS) -o $*.o -c $*.c
-
-%.lo: %.c
-	$(CC) -fPIC $(QUIRC_CFLAGS) -o $*.lo -c $*.c
+	$(CC) -fPIC $(QUIRC_CFLAGS) -o $*.o -c $*.c
 
 install: libquirc.a libquirc.so quirc-demo quirc-scanner
 	install -o root -g root -m 0644 lib/quirc.h $(DESTDIR)$(PREFIX)/include


### PR DESCRIPTION
These changes allow building quirc on BSDs (namely OpenBSD).  While at it, I added several unrelated improvements:
* allow overriding default compiler flags and providing additional linker flags,
* use PIC objects for static library as well (instead of building a separate set of non-PIC objects),
* instead of hard-coding shared library name with `-Wl,-soname=` just compile it with proper name.

This PR also drops symlinks for shared library.