### PR TITLE
Consistant typing for test timing variables

### DIFF
--- a/tests/qrtest.c
+++ b/tests/qrtest.c
@@ -86,8 +86,8 @@ static int scan_file(const char *path, const char *filename,
 	int len = strlen(filename);
 	const char *ext;
 	struct timespec tp;
-	long start;
-	long total_start;
+	unsigned int start;
+	unsigned int total_start;
 	int ret;
 	int i;
 


### PR DESCRIPTION
This is a cosmetic change fixing my own fault: in c13db788bbd4ee30fed90ae56acf14f7527b2b17 I switched `clock_t` variables in `scan_file()` function to `long`, but I forgot to switch them to `unsigned int` in 1de1a466b882011fcb28c29077ce392c4b3b238c.  I don't think they can overflow, but for the sake of correctness they should be switched as well.