### PR TITLE
Avoid division by zero.

### DIFF
--- a/lib/identify.c
+++ b/lib/identify.c
@@ -201,17 +201,19 @@ static void threshold(struct quirc *q)
 				u = x;
 			}
 
-			avg_w = (avg_w * (threshold_s - 1)) /
-				threshold_s + row[w];
-			avg_u = (avg_u * (threshold_s - 1)) /
-				threshold_s + row[u];
+			if (threshold_s > 0) {
+				avg_w = (avg_w * (threshold_s - 1)) /
+					threshold_s + row[w];
+				avg_u = (avg_u * (threshold_s - 1)) /
+					threshold_s + row[u];
+			}
 
 			row_average[w] += avg_w;
 			row_average[u] += avg_u;
 		}
 
 		for (x = 0; x < q->w; x++) {
-			if (row[x] < row_average[x] *
+			if (threshold_s > 0 && row[x] < row_average[x] *
 			    (100 - THRESHOLD_T) / (200 * threshold_s))
 				row[x] = QUIRC_PIXEL_BLACK;
 			else


### PR DESCRIPTION
Before this patch, small images (i.e. 7x7 pixels or less) could trigger
SIGFPE because of a (integer) division by zero.

Can be easily reproduced using for example https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png:
```
% file ~/Downloads/{1x1.png,7x7.png,8x8.png}
/home/alex/Downloads/1x1.png: PNG image data, 1 x 1, 1-bit colormap, non-interlaced
/home/alex/Downloads/7x7.png: PNG image data, 7 x 7, 1-bit colormap, non-interlaced
/home/alex/Downloads/8x8.png: PNG image data, 8 x 8, 1-bit colormap, non-interlaced
```
Before this patch
----------------------
```
% ./qrtest ~/Downloads/1x1.png
quirc test program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

                                          Time (ms)       Count
  Filename                         Load    ID Total    ID   Dec
-------------------------------------------------------------------------------
zsh: floating point exception  ./qrtest ~/Downloads/1x1.png
```
```
% ./qrtest ~/Downloads/7x7.png
quirc test program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

                                          Time (ms)       Count
  Filename                         Load    ID Total    ID   Dec
-------------------------------------------------------------------------------
zsh: floating point exception  ./qrtest ~/Downloads/7x7.png
```
```
% ./qrtest ~/Downloads/8x8.png
quirc test program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

                                          Time (ms)       Count
  Filename                         Load    ID Total    ID   Dec
-------------------------------------------------------------------------------
  8x8.png                       :     0     0     0     0     0
```
After this patch
--------------------
```
% ./qrtest ~/Downloads/1x1.png
quirc test program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

                                          Time (ms)       Count
  Filename                         Load    ID Total    ID   Dec
-------------------------------------------------------------------------------
  1x1.png                       :     0     0     0     0     0
```
```
% ./qrtest ~/Downloads/7x7.png
quirc test program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

                                          Time (ms)       Count
  Filename                         Load    ID Total    ID   Dec
-------------------------------------------------------------------------------
  7x7.png                       :     0     0     0     0     0
```
```
% ./qrtest ~/Downloads/8x8.png
quirc test program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

                                          Time (ms)       Count
  Filename                         Load    ID Total    ID   Dec
-------------------------------------------------------------------------------
  8x8.png                       :     0     0     0     0     0
```