### PR TITLE
identify: fix warning

### DIFF
--- a/lib/identify.c
+++ b/lib/identify.c
@@ -427,7 +427,7 @@ static void finder_scan(struct quirc *q, int y)
 {
 	quirc_pixel_t *row = q->pixels + y * q->w;
 	int x;
-	int last_color;
+	int last_color = 0;
 	int run_length = 0;
 	int run_count = 0;
 	int pb[5];


### PR DESCRIPTION
Fix the following warning when compiling with GCC 6:

lib/identify.c: In function ‘quirc_end’:
lib/identify.c:430:6: warning: ‘last_color’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  int last_color;
      ^~~~~~~~~~