### PR TITLE
Fix Kanji decoding.

### DIFF
--- a/lib/decode.c
+++ b/lib/decode.c
@@ -799,7 +799,7 @@ static quirc_decode_error_t decode_kanji(struct quirc_data *data,
 			/* bytes are in the range 0x8140 to 0x9FFC */
 			sjw = intermediate + 0x8140;
 		} else {
-			/* bytes are in the range 0x8140 to 0x9FFC */
+			/* bytes are in the range 0xE040 to 0xEBBF */
 			sjw = intermediate + 0xc140;
 		}
 

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -790,12 +790,18 @@ static quirc_decode_error_t decode_kanji(struct quirc_data *data,
 
 	for (i = 0; i < count; i++) {
 		int d = take_bits(ds, 13);
+		int msB = d / 0xc0;
+		int lsB = d % 0xc0;
+		int intermediate = (msB << 8) | lsB;
 		uint16_t sjw;
 
-		if (d + 0x8140 >= 0x9ffc)
-			sjw = d + 0x8140;
-		else
-			sjw = d + 0xc140;
+		if (intermediate + 0x8140 <= 0x9ffc) {
+			/* bytes are in the range 0x8140 to 0x9FFC */
+			sjw = intermediate + 0x8140;
+		} else {
+			/* bytes are in the range 0x8140 to 0x9FFC */
+			sjw = intermediate + 0xc140;
+		}
 
 		data->payload[data->payload_len++] = sjw >> 8;
 		data->payload[data->payload_len++] = sjw & 0xff;


### PR DESCRIPTION
Before this patch, Kanji decoding was broken.

# testing

To ease the eyes, a trivial patch is needed for `tests/dbgutil.c`:
https://gist.github.com/kAworu/e066f1c8f2f00aadc3e6ac48ff937ea9

The test image is a simple QR Code (version=1,level=L,mode=KANJI) created with https://github.com/kAworu/node-quirc/blob/master/test/data/generated/qrgen.c,
The payload is `kanji_data[4] = {0x93, 0x5f,0xe4, 0xaa}; /* 点茗 in Shift-JIS */`

![version 01 level l mode kanji](https://cloud.githubusercontent.com/assets/109415/26594871/b42305a4-4569-11e7-9e0d-47786468aa18.png)

## Before this PR patch
```
% ./inspect version=01,level=L,mode=KANJI.png 
quirc inspection program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

1 QR-codes found:

    21 cells, corners: (12,12) (75,12) (75,75) (12,75)
    [][][][][][][]      []  []  [][][][][][][]
    []          []          []  []          []
    []  [][][]  []  []  []      []  [][][]  []
    []  [][][]  []          []  []  [][][]  []
    []  [][][]  []    []  [][]  []  [][][]  []
    []          []    [][][]    []          []
    [][][][][][][]  []  []  []  [][][][][][][]
                    []  []                    
    [][][]  [][][][][]  []  [][][]      []    
    []    [][]        [][][]  []  []    []  []
                []  [][]  []  [][][]      []  
      [][]    []  [][][]  [][][]  [][][][][]  
      []  []  [][][]  [][][]  [][][]      []  
                    []          []    [][][][]
    [][][][][][][]  [][][]  []      []    [][]
    []          []  []  []      []    [][][][]
    []  [][][]  []  []      []  []  []  []  []
    []  [][][]  []    []  []  []  []  []  []  
    []  [][][]  []  [][]  []  [][][]    []  []
    []          []  []  [][][][]  [][][]  []  
    [][][][][][][]  [][][][]  [][][]    []    

  Decoding successful:
    Version: 1
    ECC level: L
    Mask: 0
    Data type: 8 (KANJI)
    Length: 4
    Payload: ce df db ea 

```

## After this PR patch
```
% ./inspect.patched version=01,level=L,mode=KANJI.png 
quirc inspection program
Copyright (C) 2010-2012 Daniel Beer <dlbeer@gmail.com>
Library version: 1.0

1 QR-codes found:

    21 cells, corners: (12,12) (75,12) (75,75) (12,75)
    [][][][][][][]      []  []  [][][][][][][]
    []          []          []  []          []
    []  [][][]  []  []  []      []  [][][]  []
    []  [][][]  []          []  []  [][][]  []
    []  [][][]  []    []  [][]  []  [][][]  []
    []          []    [][][]    []          []
    [][][][][][][]  []  []  []  [][][][][][][]
                    []  []                    
    [][][]  [][][][][]  []  [][][]      []    
    []    [][]        [][][]  []  []    []  []
                []  [][]  []  [][][]      []  
      [][]    []  [][][]  [][][]  [][][][][]  
      []  []  [][][]  [][][]  [][][]      []  
                    []          []    [][][][]
    [][][][][][][]  [][][]  []      []    [][]
    []          []  []  []      []    [][][][]
    []  [][][]  []  []      []  []  []  []  []
    []  [][][]  []    []  []  []  []  []  []  
    []  [][][]  []  [][]  []  [][][]    []  []
    []          []  []  [][][][]  [][][]  []  
    [][][][][][][]  [][][][]  [][][]    []    

  Decoding successful:
    Version: 1
    ECC level: L
    Mask: 0
    Data type: 8 (KANJI)
    Length: 4
    Payload: 93 5f e4 aa 

```