### PR TITLE
Fix a potential use-after-free on quirc_resize failure.

### DIFF
--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -36,8 +36,7 @@ struct quirc *quirc_new(void)
 
 void quirc_destroy(struct quirc *q)
 {
-	if (q->image)
-		free(q->image);
+	free(q->image);
 	if (sizeof(*q->image) != sizeof(*q->pixels))
 		free(q->pixels);
 
@@ -47,23 +46,18 @@ void quirc_destroy(struct quirc *q)
 int quirc_resize(struct quirc *q, int w, int h)
 {
 	uint8_t *new_image = realloc(q->image, w * h);
-
 	if (!new_image)
 		return -1;
+	q->image = new_image;
 
 	if (sizeof(*q->image) != sizeof(*q->pixels)) {
 		size_t new_size = w * h * sizeof(quirc_pixel_t);
 		quirc_pixel_t *new_pixels = realloc(q->pixels, new_size);
-
-		if (!new_pixels) {
-			free(new_image);
+		if (!new_pixels)
 			return -1;
-		}
-
 		q->pixels = new_pixels;
 	}
 
-	q->image = new_image;
 	q->w = w;
 	q->h = h;
 

--- a/lib/quirc.h
+++ b/lib/quirc.h
@@ -40,8 +40,7 @@ void quirc_destroy(struct quirc *q);
  * specified before codes can be analyzed.
  *
  * This function returns 0 on success, or -1 if sufficient memory could
- * not be allocated. On failure the QR-code recognizer should not be
- * used and is expected to be given to quirc_destroy() for cleanup.
+ * not be allocated.
  */
 int quirc_resize(struct quirc *q, int w, int h);
 

--- a/lib/quirc.h
+++ b/lib/quirc.h
@@ -40,7 +40,8 @@ void quirc_destroy(struct quirc *q);
  * specified before codes can be analyzed.
  *
  * This function returns 0 on success, or -1 if sufficient memory could
- * not be allocated.
+ * not be allocated. On failure the QR-code recognizer should not be
+ * used and is expected to be given to quirc_destroy() for cleanup.
  */
 int quirc_resize(struct quirc *q, int w, int h);
 


### PR DESCRIPTION
This is a preparation patch before removing the use of VLA.

The commit message should be enough to understand the rational of the patch.

Alternatively, I believe that the state of `q` could be made consistent by safely using the minimum values for both `q->w` and `q->h`:
```c
q->h = MIN(q->h, h);
q->w = MIN(q->w, w);
```
but I feel that's over-engeneering code for a corner case. Correct me if I'm wrong.