### PR TITLE
Refactoring to remove the use of c99 VLA

### DIFF
--- a/demo/mjpeg.c
+++ b/demo/mjpeg.c
@@ -15,6 +15,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <setjmp.h>
 #include <jpeglib.h>
@@ -224,21 +225,25 @@ int mjpeg_decode_rgb32(struct mjpeg_decoder *mj,
 		return -1;
 	}
 
+	uint8_t *rgb = calloc(mj->dinfo.image_width, 3);
+	if (!rgb) {
+		fprintf(stderr, "memory allocation failed\n");
+		return -1;
+	}
 	while (mj->dinfo.output_scanline < mj->dinfo.image_height) {
-		uint8_t rgb[mj->dinfo.image_width * 3];
-		uint8_t *output = rgb;
 		uint8_t *scr = out + pitch * mj->dinfo.output_scanline;
 		int i;
 
-		jpeg_read_scanlines(&mj->dinfo, &output, 1);
+		jpeg_read_scanlines(&mj->dinfo, &rgb, 1);
 		for (i = 0; i < mj->dinfo.image_width; i++) {
-			scr[0] = output[2];
-			scr[1] = output[1];
-			scr[2] = output[0];
+			scr[0] = rgb[2];
+			scr[1] = rgb[1];
+			scr[2] = rgb[0];
 			scr += 4;
-			output += 3;
+			rgb += 3;
 		}
 	}
+	free(rgb);
 
 	jpeg_finish_decompress(&mj->dinfo);
 

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -196,9 +196,7 @@ static void threshold(struct quirc *q)
 		threshold_s = THRESHOLD_S_MIN;
 
 	for (y = 0; y < q->h; y++) {
-		int row_average[q->w];
-
-		memset(row_average, 0, sizeof(row_average));
+		memset(q->row_average, 0, q->w * sizeof(int));
 
 		for (x = 0; x < q->w; x++) {
 			int w, u;
@@ -216,12 +214,12 @@ static void threshold(struct quirc *q)
 			avg_u = (avg_u * (threshold_s - 1)) /
 				threshold_s + row[u];
 
-			row_average[w] += avg_w;
-			row_average[u] += avg_u;
+			q->row_average[w] += avg_w;
+			q->row_average[u] += avg_u;
 		}
 
 		for (x = 0; x < q->w; x++) {
-			if (row[x] < row_average[x] *
+			if (row[x] < q->row_average[x] *
 			    (100 - THRESHOLD_T) / (200 * threshold_s))
 				row[x] = QUIRC_PIXEL_BLACK;
 			else

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -38,7 +38,7 @@ void quirc_destroy(struct quirc *q)
 {
 	free(q->image);
 	/* q->pixels may alias q->image when their type representation is of the
-	   same size, so we need to be careful here */
+	   same size, so we need to be careful here to avoid a double free */
 	if (sizeof(*q->image) != sizeof(*q->pixels))
 		free(q->pixels);
 	free(q->row_average);

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -77,6 +77,7 @@ struct quirc_grid {
 struct quirc {
 	uint8_t			*image;
 	quirc_pixel_t		*pixels;
+	int			*row_average; /* used by threshold() */
 	int			w;
 	int			h;
 


### PR DESCRIPTION
PR to avoid using c99 VLA as discussed on https://github.com/dlbeer/quirc/issues/36#issuecomment-306399797.

I wrote a [Coccinelle](http://coccinelle.lip6.fr/) semantic patch to track them down (see [here](https://gist.github.com/kAworu/14910868052bb248e55ea73802f45d5b), it's not perfect but fine enough for our case).

## Before the patch
```
% spatch -I /usr/include -I /usr/local/include -I . -sp_file vla.cocci .           
init_defs_builtins: /usr/lib/coccinelle/standard.h
HANDLING: ./demo/convert.c
HANDLING: ./demo/demo.c
HANDLING: ./demo/camera.c
HANDLING: ./demo/scanner.c
HANDLING: ./demo/demoutil.c
HANDLING: ./demo/dthash.c
HANDLING: ./demo/mjpeg.c
* TODO [[view:./demo/mjpeg.c::face=ovl-face1::linb=228::colb=10::cole=13][./demo/mjpeg.c::228]]
HANDLING: ./tests/qrtest.c
HANDLING: ./tests/dbgutil.c
HANDLING: ./tests/inspect.c
HANDLING: ./lib/quirc.c
HANDLING: ./lib/version_db.c
HANDLING: ./lib/identify.c
* TODO [[view:./lib/identify.c::face=ovl-face1::linb=199::colb=6::cole=17][./lib/identify.c::199]]
HANDLING: ./lib/decode.c
```
## After 
```
 % spatch -I /usr/include -I /usr/local/include -I . -sp_file vla.cocci .
init_defs_builtins: /usr/lib/coccinelle/standard.h
HANDLING: ./demo/convert.c
HANDLING: ./demo/demo.c
HANDLING: ./demo/camera.c
HANDLING: ./demo/scanner.c
HANDLING: ./demo/demoutil.c
HANDLING: ./demo/dthash.c
HANDLING: ./demo/mjpeg.c
HANDLING: ./tests/qrtest.c
HANDLING: ./tests/dbgutil.c
HANDLING: ./tests/inspect.c
HANDLING: ./lib/quirc.c
HANDLING: ./lib/version_db.c
HANDLING: ./lib/identify.c
HANDLING: ./lib/decode.c
```