### PR TITLE
Replaced existing threshold function with Otsu threshold algorithm

### DIFF
--- a/lib/identify.c
+++ b/lib/identify.c
@@ -174,55 +174,55 @@ static void flood_fill_seed(struct quirc *q, int x, int y, int from, int to,
  * Adaptive thresholding
  */
 
-uint8_t otsu(struct quirc *q)
+uint8_t otsu(const struct quirc *q)
 {
-    int numPixels = q->w * q->h;
+	int numPixels = q->w * q->h;
 
-    // Calculate histogram
-    const int HISTOGRAM_SIZE = 256;
-    unsigned int histogram[HISTOGRAM_SIZE];
-    memset(histogram, 0, (HISTOGRAM_SIZE) * sizeof(unsigned int));
-    uint8_t* ptr = q->image;
-    int length = numPixels;
-    while (length--) {
-        uint8_t value = *ptr++;
-        histogram[value]++;
-    }
+	// Calculate histogram
+	const int HISTOGRAM_SIZE = 256;
+	unsigned int histogram[HISTOGRAM_SIZE];
+	memset(histogram, 0, (HISTOGRAM_SIZE) * sizeof(unsigned int));
+	uint8_t* ptr = q->image;
+	int length = numPixels;
+	while (length--) {
+		uint8_t value = *ptr++;
+		histogram[value]++;
+	}
 
-    // Calculate weighted sum of histogram values
-    int sum = 0;
-    for (int i = 0; i < HISTOGRAM_SIZE; ++i) {
-        sum += i * histogram[i];
-    }
+	// Calculate weighted sum of histogram values
+	int sum = 0;
+	for (int i = 0; i < HISTOGRAM_SIZE; ++i) {
+		sum += i * histogram[i];
+	}
 
-    // Compute threshold
-    int sumB = 0;
-    int q1 = 0;
-    double max = 0;
-    uint8_t threshold = 0;
-    for (int i = 0; i < HISTOGRAM_SIZE; ++i) {
-        // Weighted background
-        q1 += histogram[i];
-        if (q1 == 0)
-            continue;
+	// Compute threshold
+	int sumB = 0;
+	int q1 = 0;
+	double max = 0;
+	uint8_t threshold = 0;
+	for (int i = 0; i < HISTOGRAM_SIZE; ++i) {
+		// Weighted background
+		q1 += histogram[i];
+		if (q1 == 0)
+			continue;
 
-        // Weighted foreground
-        const int q2 = numPixels - q1;
-        if (q2 == 0)
-            break;
+		// Weighted foreground
+		const int q2 = numPixels - q1;
+		if (q2 == 0)
+			break;
 
-        sumB += i * histogram[i];
-        const double m1 = (double)sumB / q1;
-        const double m2 = ((double)sum - sumB) / q2;
-        const double m1m2 = m1 - m2;
-        const double variance = m1m2 * m1m2 * q1 * q2;
-        if (variance > max) {
-            threshold = i;
-            max = variance;
-        }
-    }
+		sumB += i * histogram[i];
+		const double m1 = (double)sumB / q1;
+		const double m2 = ((double)sum - sumB) / q2;
+		const double m1m2 = m1 - m2;
+		const double variance = m1m2 * m1m2 * q1 * q2;
+		if (variance > max) {
+			threshold = i;
+			max = variance;
+		}
+	}
 
-    return threshold;
+	return threshold;
 }
 
 static void area_count(void *user_data, int y, int left, int right)
@@ -1071,17 +1071,17 @@ static void test_grouping(struct quirc *q, int i)
 
 static void pixels_setup(struct quirc *q, uint8_t threshold)
 {
-    if (sizeof(*q->image) == sizeof(*q->pixels)) {
-        q->pixels = (quirc_pixel_t *)q->image;
-    }
+	if (sizeof(*q->image) == sizeof(*q->pixels)) {
+		q->pixels = (quirc_pixel_t *)q->image;
+	}
 
-    uint8_t* source = q->image;
-    quirc_pixel_t* dest = q->pixels;
-    int length = q->w * q->h;
-    while (length--) {
-        uint8_t value = *source++;
-        *dest++ = (value < threshold) ? QUIRC_PIXEL_BLACK : QUIRC_PIXEL_WHITE;
-    }
+	uint8_t* source = q->image;
+	quirc_pixel_t* dest = q->pixels;
+	int length = q->w * q->h;
+	while (length--) {
+		uint8_t value = *source++;
+		*dest++ = (value < threshold) ? QUIRC_PIXEL_BLACK : QUIRC_PIXEL_WHITE;
+	}
 }
 
 uint8_t *quirc_begin(struct quirc *q, int *w, int *h)
@@ -1102,8 +1102,8 @@ void quirc_end(struct quirc *q)
 {
 	int i;
 
-    uint8_t threshold = otsu(q);
-    pixels_setup(q, threshold);
+	uint8_t threshold = otsu(q);
+	pixels_setup(q, threshold);
 
 	for (i = 0; i < q->h; i++)
 		finder_scan(q, i);

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -41,7 +41,6 @@ void quirc_destroy(struct quirc *q)
 	   same size, so we need to be careful here to avoid a double free */
 	if (sizeof(*q->image) != sizeof(*q->pixels))
 		free(q->pixels);
-	free(q->row_average);
 	free(q);
 }
 
@@ -49,7 +48,6 @@ int quirc_resize(struct quirc *q, int w, int h)
 {
 	uint8_t		*image  = NULL;
 	quirc_pixel_t	*pixels = NULL;
-	int		*row_average = NULL;
 
 	/*
 	 * XXX: w and h should be size_t (or at least unsigned) as negatives
@@ -88,11 +86,6 @@ int quirc_resize(struct quirc *q, int w, int h)
 			goto fail;
 	}
 
-	/* alloc a new buffer for q->row_average */
-	row_average = calloc(w, sizeof(int));
-	if (!row_average)
-		goto fail;
-
 	/* alloc succeeded, update `q` with the new size and buffers */
 	q->w = w;
 	q->h = h;
@@ -102,15 +95,12 @@ int quirc_resize(struct quirc *q, int w, int h)
 		free(q->pixels);
 		q->pixels = pixels;
 	}
-	free(q->row_average);
-	q->row_average = row_average;
 
 	return 0;
 	/* NOTREACHED */
 fail:
 	free(image);
 	free(pixels);
-	free(row_average);
 
 	return -1;
 }

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -77,7 +77,6 @@ struct quirc_grid {
 struct quirc {
 	uint8_t			*image;
 	quirc_pixel_t		*pixels;
-	int			*row_average; /* used by threshold() */
 	int			w;
 	int			h;
 


### PR DESCRIPTION
Hi Daniel

I replaced the existing threshold function with another one based on [Otsu's algorithm](https://en.wikipedia.org/wiki/Otsu%27s_method). Not only does this improve the overall quality of QR code detection, the whole detection process is also considerably faster. On my Intel desktop system detection time improved by a factor of 2.5 on average (even more for images with a lot of noise or bad lighting).

Would you mind having a look at my pull request?

Regards,
Claudio

**Example**
*Original image:*
![grayscale](https://user-images.githubusercontent.com/339950/56959298-3c4f6200-6b4d-11e9-8cde-089416ce10e9.jpg)

*Binarization with old threshold function:*
![binarized-old](https://user-images.githubusercontent.com/339950/56959332-64d75c00-6b4d-11e9-9372-dfe7abea3aa0.png)

*Binarization with new Otsu-based threshold function:*
![binarized-new](https://user-images.githubusercontent.com/339950/56959342-6dc82d80-6b4d-11e9-8f70-689b58e4bfe2.png)
