### PR TITLE
define a QUIRC_PIXEL_ALIAS_IMAGE constant to explicit conditional path

### DIFF
--- a/lib/identify.c
+++ b/lib/identify.c
@@ -1071,7 +1071,7 @@ static void test_grouping(struct quirc *q, int i)
 
 static void pixels_setup(struct quirc *q, uint8_t threshold)
 {
-	if (sizeof(*q->image) == sizeof(*q->pixels)) {
+	if (QUIRC_PIXEL_ALIAS_IMAGE) {
 		q->pixels = (quirc_pixel_t *)q->image;
 	}
 

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -39,7 +39,7 @@ void quirc_destroy(struct quirc *q)
 	free(q->image);
 	/* q->pixels may alias q->image when their type representation is of the
 	   same size, so we need to be careful here to avoid a double free */
-	if (sizeof(*q->image) != sizeof(*q->pixels))
+	if (!QUIRC_PIXEL_ALIAS_IMAGE)
 		free(q->pixels);
 	free(q);
 }
@@ -80,7 +80,7 @@ int quirc_resize(struct quirc *q, int w, int h)
 	(void)memcpy(image, q->image, min);
 
 	/* alloc a new buffer for q->pixels if needed */
-	if (sizeof(*q->image) != sizeof(*q->pixels)) {
+	if (!QUIRC_PIXEL_ALIAS_IMAGE) {
 		pixels = calloc(newdim, sizeof(quirc_pixel_t));
 		if (!pixels)
 			goto fail;
@@ -91,7 +91,7 @@ int quirc_resize(struct quirc *q, int w, int h)
 	q->h = h;
 	free(q->image);
 	q->image = image;
-	if (sizeof(*q->image) != sizeof(*q->pixels)) {
+	if (!QUIRC_PIXEL_ALIAS_IMAGE) {
 		free(q->pixels);
 		q->pixels = pixels;
 	}

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -32,8 +32,10 @@
 #define QUIRC_PERSPECTIVE_PARAMS	8
 
 #if QUIRC_MAX_REGIONS < UINT8_MAX
+#define QUIRC_PIXEL_ALIAS_IMAGE	1
 typedef uint8_t quirc_pixel_t;
 #elif QUIRC_MAX_REGIONS < UINT16_MAX
+#define QUIRC_PIXEL_ALIAS_IMAGE	0
 typedef uint16_t quirc_pixel_t;
 #else
 #error "QUIRC_MAX_REGIONS > 65534 is not supported"


### PR DESCRIPTION
Before this patch, the "sizeof dance" was confusing, fix #54.