### PR TITLE
Respect the buffer size when decoding bits

### DIFF
--- a/lib/decode.c
+++ b/lib/decode.c
@@ -537,7 +537,8 @@ static void read_bit(const struct quirc_code *code,
 		v ^= 1;
 
 	if (v)
-		ds->raw[bytepos] |= (0x80 >> bitpos);
+		if (bytepos < QUIRC_MAX_PAYLOAD)
+			ds->raw[bytepos] |= (0x80 >> bitpos);
 
 	ds->data_bits++;
 }

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -536,9 +536,8 @@ static void read_bit(const struct quirc_code *code,
 	if (mask_bit(data->mask, i, j))
 		v ^= 1;
 
-	if (v)
-		if (bytepos < QUIRC_MAX_PAYLOAD)
-			ds->raw[bytepos] |= (0x80 >> bitpos);
+	if (v && bytepos < (sizeof(ds->raw) / sizeof(ds->raw[0])))
+		ds->raw[bytepos] |= (0x80 >> bitpos);
 
 	ds->data_bits++;
 }


### PR DESCRIPTION
read_bit() is the first place where the decoded result was kept. The buffer would overflow if the decoded bits exceeds the configuration. Stop reading bits if the buffer overflows.