### PR TITLE
Refactored some c99 features

### DIFF
--- a/lib/identify.c
+++ b/lib/identify.c
@@ -180,9 +180,8 @@ static uint8_t otsu(const struct quirc *q)
 	int numPixels = q->w * q->h;
 
 	// Calculate histogram
-	const int HISTOGRAM_SIZE = 256;
-	unsigned int histogram[HISTOGRAM_SIZE];
-	memset(histogram, 0, (HISTOGRAM_SIZE) * sizeof(unsigned int));
+	unsigned int histogram[UINT8_MAX + 1];
+	(void)memset(histogram, 0, sizeof(histogram));
 	uint8_t* ptr = q->image;
 	int length = numPixels;
 	while (length--) {
@@ -191,8 +190,9 @@ static uint8_t otsu(const struct quirc *q)
 	}
 
 	// Calculate weighted sum of histogram values
-	int sum = 0;
-	for (int i = 0; i < HISTOGRAM_SIZE; ++i) {
+	unsigned int sum = 0;
+	unsigned int i = 0;
+	for (i = 0; i <= UINT8_MAX; ++i) {
 		sum += i * histogram[i];
 	}
 
@@ -201,7 +201,7 @@ static uint8_t otsu(const struct quirc *q)
 	int q1 = 0;
 	double max = 0;
 	uint8_t threshold = 0;
-	for (int i = 0; i < HISTOGRAM_SIZE; ++i) {
+	for (i = 0; i <= UINT8_MAX; ++i) {
 		// Weighted background
 		q1 += histogram[i];
 		if (q1 == 0)


### PR DESCRIPTION
Fixes #68

Using `UINT8_MAX` here explicit that any `uint8_t` value is a valid index in the `histogram` array. Looping over the `uint8_t` range make it obvious that `threshold = i` is safe.