### PR TITLE
Pass user-provided buffer into new quirc_init() function

### DIFF
--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -37,9 +37,8 @@ struct quirc *quirc_new(void)
 
 void quirc_destroy(struct quirc *q)
 {
-	if (!q->quirc_owns_buffers) {
+	if (!q->quirc_owns_buffers)
 		return;
-	}
 
 	free(q->image);
 	/* q->pixels may alias q->image when their type representation is of the

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -71,7 +71,6 @@ int quirc_resize(struct quirc *q, int w, int h)
 	uint8_t		*image  = NULL;
 	quirc_pixel_t	*pixels = NULL;
 
-	/* Restrict use of this function when quirc_init() was used */
 	if (!q->need_to_free) {
 		/*
 		 * Just update the internal sizes and assume the caller knows what they

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -52,15 +52,19 @@ void quirc_destroy(struct quirc *q)
 
 int quirc_init(struct quirc* q, int w, int h, void* image)
 {
-	if (!q || !image || q->quirc_owns_buffers || !QUIRC_PIXEL_ALIAS_IMAGE) {
+	if (!q || !image || q->quirc_owns_buffers || !QUIRC_PIXEL_ALIAS_IMAGE)
 		return -1;
-	}
+
+	/*
+	 * XXX: Same sanity check as in quirc_resize() for the same reasons.
+	 */
+	if (w < 0 || h < 0)
+		return -1;
 
 	memset(q, 0, sizeof(*q));
 	q->w = w;
 	q->h = h;
 	q->image = image;
-
 	return 0;
 }
 
@@ -71,10 +75,9 @@ int quirc_resize(struct quirc *q, int w, int h)
 	quirc_pixel_t	*pixels = NULL;
 
 	/* Restrict use of this function when quirc_init() was used */
-	if (!q->quirc_owns_buffers) {
+	if (!q->quirc_owns_buffers)
 		// don't 'goto fail' here since we don't want to free the user buffers
 		return -1;
-	}
 
 	/*
 	 * XXX: w and h should be size_t (or at least unsigned) as negatives

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -20,7 +20,7 @@
 
 const char *quirc_version(void)
 {
-	return "1.0";
+	return "1.1";
 }
 
 struct quirc *quirc_new(void)

--- a/lib/quirc.h
+++ b/lib/quirc.h
@@ -35,12 +35,13 @@ struct quirc *quirc_new(void);
 
 /* Alternate constructor function that accepts buffer pointers so that
  * no malloc() or free() calls are necessary.  Useful on embedded systems
- * to help avoid allocating more buffer space than might be available.
- * Do not call quirc_new() if you call quirc_init().
- * 
- * You cannot call quirc_resize() if you use this constructor.
+ * to help avoid allocating more buffer space than might be available, or
+ * to use a memory buffer that is statically allocated or allocated with
+ * something other than malloc().
+ *
+ * Note that QUIRC_PIXEL_ALIAS_IMAGE must be true (1) to us this constructor.
  */
-int quirc_init(struct quirc* q, int w, int h, void* image);
+int quirc_init(struct quirc *q, int w, int h, uint8_t *image);
 
 /* Destroy a QR-code recognizer. */
 void quirc_destroy(struct quirc *q);

--- a/lib/quirc.h
+++ b/lib/quirc.h
@@ -39,7 +39,7 @@ struct quirc *quirc_new(void);
  * to use a memory buffer that is statically allocated or allocated with
  * something other than malloc().
  *
- * Note that QUIRC_PIXEL_ALIAS_IMAGE must be true (1) to us this constructor.
+ * Note that QUIRC_PIXEL_ALIAS_IMAGE must be true (1) to use this constructor.
  */
 int quirc_init(struct quirc *q, int w, int h, uint8_t *image);
 

--- a/lib/quirc.h
+++ b/lib/quirc.h
@@ -33,6 +33,15 @@ const char *quirc_version(void);
  */
 struct quirc *quirc_new(void);
 
+/* Alternate constructor function that accepts buffer pointers so that
+ * no malloc() or free() calls are necessary.  Useful on embedded systems
+ * to help avoid allocating more buffer space than might be available.
+ * Do not call quirc_new() if you call quirc_init().
+ * 
+ * You cannot call quirc_resize() if you use this constructor.
+ */
+int quirc_init(struct quirc* q, int w, int h, void* image);
+
 /* Destroy a QR-code recognizer. */
 void quirc_destroy(struct quirc *q);
 

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -81,7 +81,7 @@ struct quirc {
 	quirc_pixel_t		*pixels;
 	int			w;
 	int			h;
-	int			quirc_owns_buffers;
+	int			need_to_free;
 
 	int			num_regions;
 	struct quirc_region	regions[QUIRC_MAX_REGIONS];

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -81,6 +81,7 @@ struct quirc {
 	quirc_pixel_t		*pixels;
 	int			w;
 	int			h;
+	int			quirc_owns_buffers;
 
 	int			num_regions;
 	struct quirc_region	regions[QUIRC_MAX_REGIONS];


### PR DESCRIPTION
The purpose of this PR is to prevent double memory allocation on embedded systems

Addresses #74.

I can't build the Mac version of this and didn't get a chance to test on a Linux VM yet.

I will do that tomorrow, but it does compile the lib on my Mac, and I'm using the same code on my embedded simulator and it's working.