### PR TITLE
Fix compiler warning

### DIFF
--- a/tests/inspect.c
+++ b/tests/inspect.c
@@ -150,7 +150,7 @@ static void draw_grid(SDL_Surface *screen, struct quirc *q, int index)
 
 	for (i = 0; i < 3; i++) {
 		struct quirc_capstone *cap = &q->capstones[qr->caps[i]];
-		char buf[8];
+		char buf[16];
 
 		snprintf(buf, sizeof(buf), "%d.%c", index, "ABC"[i]);
 		stringColor(screen, cap->center.x, cap->center.y, buf,


### PR DESCRIPTION
Compiler gives this warning because an integer can take up more space
tests/inspect.c:155:3: note: ‘snprintf’ output between 4 and 13 bytes into a destination of size 8
   snprintf(buf, sizeof(buf), "%d.%c", index, "ABC"[i]);
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~