### PR TITLE
Added support for CMake build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.6.0 FATAL_ERROR)
+
+project(quirc VERSION 0.1 LANGUAGES C)
+
+FILE(GLOB QUIRC_SRC_FILES lib/*.c)
+
+add_library(quirc STATIC ${QUIRC_SRC_FILES})
+
+install(TARGETS quirc EXPORT quirc DESTINATION "lib")
+install(FILES "lib/quirc.h" DESTINATION "include/quirc")
+install(EXPORT quirc DESTINATION "lib/cmake/quirc")
+install(FILES "cmake/quirc-config.cmake" DESTINATION "lib/cmake/quirc")

--- a/cmake/quirc-config.cmake
+++ b/cmake/quirc-config.cmake
@@ -1,0 +1,2 @@
+get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(${SELF_DIR}/quirc.cmake)


### PR DESCRIPTION
Allowing to build Quirc with CMake would make it compiler/platform independant while facilitating its integration with other pieces of software.