### PR TITLE
avoid annoying sdl msg if compile library only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 
 CC ?= gcc
 PREFIX ?= /usr/local
-SDL_CFLAGS != pkg-config --cflags sdl
-SDL_LIBS != pkg-config --libs sdl
+inspect quirc-demo: SDL_CFLAGS = $(shell pkg-config --cflags sdl)
+inspect quirc-demo: SDL_LIBS = $(shell pkg-config --libs sdl)
 
 LIB_VERSION = 1.0
 


### PR DESCRIPTION
  if only library is compiled without libsdl installed,
  pkg-config will prompt warning of sdl each time.
  Use target-specific variable to avoid this problem.