### PR TITLE
Support horizontally flipped QR-codes according to ISO 18004:2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ libquirc.so*
 .*.swp
 *~
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ for (i = 0; i < num_codes; i++) {
 `quirc_code` and `quirc_data` are flat structures which don't need to be
 initialized or freed after use.
 
+In case you also need to support horizontally flipped QR-codes (mirrored
+images according to ISO 18004:2015, pages 6 and 62), you can make a second
+decode attempt with the flipped image data whenever you get an ECC failure:
+
+```C
+    err = quirc_decode(&code, &data);
+    if (err == QUIRC_ERROR_DATA_ECC) {
+        quirc_flip(&code);
+        err = quirc_decode(&code, &data);
+    }
+
+    if (err)
+        printf("DECODE FAILED: %s\n", quirc_strerror(err));
+    else
+        printf("Data: %s\n", data.payload);
+```
+
 Copyright
 ---------
 Copyright (C) 2010-2012 Daniel Beer <<dlbeer@gmail.com>>

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -916,3 +916,19 @@ quirc_decode_error_t quirc_decode(const struct quirc_code *code,
 
 	return QUIRC_SUCCESS;
 }
+
+void quirc_flip(struct quirc_code *code)
+{
+    struct quirc_code flipped;
+    memset(&flipped, 0, sizeof(flipped));
+    int offset = 0;
+    for (int y = 0, sx = 0; y < code->size; y++, sx++) {
+        for (int x = 0, sy = 0; x < code->size; x++, sy++) {
+            if (grid_bit(code, sx, sy)) {
+                flipped.cell_bitmap[offset >> 3] |= (1 << (offset & 7));
+            }
+            offset++;
+        }
+    }
+    memcpy(&code->cell_bitmap, &flipped.cell_bitmap, sizeof(flipped.cell_bitmap));
+}

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -919,16 +919,15 @@ quirc_decode_error_t quirc_decode(const struct quirc_code *code,
 
 void quirc_flip(struct quirc_code *code)
 {
-    struct quirc_code flipped;
-    memset(&flipped, 0, sizeof(flipped));
-    int offset = 0;
-    for (int y = 0, sx = 0; y < code->size; y++, sx++) {
-        for (int x = 0, sy = 0; x < code->size; x++, sy++) {
-            if (grid_bit(code, sx, sy)) {
-                flipped.cell_bitmap[offset >> 3] |= (1 << (offset & 7));
-            }
-            offset++;
-        }
-    }
-    memcpy(&code->cell_bitmap, &flipped.cell_bitmap, sizeof(flipped.cell_bitmap));
+	struct quirc_code flipped = {0};
+	unsigned int offset = 0;
+	for (int y = 0; y < code->size; y++) {
+		for (int x = 0; x < code->size; x++) {
+			if (grid_bit(code, y, x)) {
+				flipped.cell_bitmap[offset >> 3u] |= (1u << (offset & 7u));
+			}
+			offset++;
+		}
+	}
+	memcpy(&code->cell_bitmap, &flipped.cell_bitmap, sizeof(flipped.cell_bitmap));
 }

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -1140,7 +1140,7 @@ void quirc_extract(const struct quirc *q, int index,
 		int x;
 		for (x = 0; x < qr->grid_size; x++) {
 			if (read_cell(q, index, x, y) > 0) {
-		                code->cell_bitmap[i >> 3] |= (1 << (i & 7));
+				code->cell_bitmap[i >> 3] |= (1 << (i & 7));
 			}
 			i++;
 		}

--- a/lib/quirc.h
+++ b/lib/quirc.h
@@ -168,6 +168,9 @@ void quirc_extract(const struct quirc *q, int index,
 quirc_decode_error_t quirc_decode(const struct quirc_code *code,
 				  struct quirc_data *data);
 
+/* Flip a QR-code according to optional mirror feature of ISO 18004:2015 */
+void quirc_flip(struct quirc_code *code);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/inspect.c
+++ b/tests/inspect.c
@@ -34,6 +34,10 @@ static void dump_info(struct quirc *q)
 
 		quirc_extract(q, i, &code);
 		err = quirc_decode(&code, &data);
+		if (err == QUIRC_ERROR_DATA_ECC) {
+			quirc_flip(&code);
+			err = quirc_decode(&code, &data);
+		}
 
 		dump_cells(&code);
 		printf("\n");


### PR DESCRIPTION
The QR-code specification supports various optional features. A newer one is "mirror imaging". I don't know in which version of the specification (2006, 2009 or 2015) it was added, but it certainly is mentioned in ISO 18004:2015:

ISO 18004: 2015, page 6, "*Mirror lmaging*":
> The arrangement of modules defined in this International Standard represents the "normal"
> orientation of the symbol. lt ls, however, possible to achieve a valid decode of a symbol in which the
> arrangement of the modules has been laterally transposed. When viewed with the finder patterns
> at the top left, top right and bottom left corners of the symbol, the effect of mirror imaging is to
> interchange the row and column positions of the modules.

ISO 18004: 2015, page 62, "*Decoding procedure overview*":
> …
> 2. Read the format Information. Release the masking pattem and perform error correction on the
> format information modules as necessary; if successful, symbol is in normal orientation, otherwise
> attempt mirror image decoding of format Information. ldentify Error Correction Level, either
> directly, in QR Code symbols, or from Micro QR Code symbol number, and data mask pattern
> reference.
> …

For the moment I decided on making the flipped detection optional by providing a new function `quirc_flip()`. It flips the modules pixmap and rotates it back to the normalized position. Then a second decode attempt can be initiated. A typical call sequence would look like this:

``` C
struct quirc_data data;

quirc_decode_error_t err = quirc_decode(&code, &data);
if (err == QUIRC_ERROR_DATA_ECC) {
    quirc_flip(&code);
    err = quirc_decode(&code, &data);
}

if (err) {
    // handle error
} else {
    // use decoded payload
}
```

The following two QR-codes represent a normal and a horizontally flipped one. Both can be correctly decoded with this small extension:

![qrcodes](https://user-images.githubusercontent.com/339950/93788699-4174eb80-fc31-11ea-8d1c-806749014b77.png)

This resolves the problem I reported in issue https://github.com/dlbeer/quirc/issues/88.