### PR TITLE
Makefile: Use = for CFLAGS, instead of ?=

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SDL_LIBS != pkg-config --libs sdl
 
 LIB_VERSION = 1.0
 
-CFLAGS ?= -O3 -Wall -fPIC
+CFLAGS = -O3 -Wall -fPIC
 QUIRC_CFLAGS = -Ilib $(CFLAGS) $(SDL_CFLAGS)
 LIB_OBJ = \
     lib/decode.o \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ additional information on stdout.
 Installation
 ------------
 To build the library and associated demos/tests, type `make`. If you need to
-decode "large" image files build with `CFLAGS="-DQUIRC_MAX_REGIONS=65534" make`
+decode "large" image files build with `make CFLAGS="-DQUIRC_MAX_REGIONS=65534"`
 instead. Note that this will increase the memory usage, it is discouraged for
 low resource devices (i.e. embedded).
 


### PR DESCRIPTION
Some make (eg. BSD make I installed with "brew install bsdmake")
have the default CFLAGS set. Using ?= here means to use the default.
I guess it isn't the intention of this Makefile.

Also, update an example to override CFLAGS accordingly.