### PR TITLE
Improve stack usage for flood filling

### DIFF
--- a/lib/identify.c
+++ b/lib/identify.c
@@ -178,21 +178,22 @@ static struct quirc_flood_fill_vars *flood_fill_call_next(
 	while (*leftp <= vars->right) {
 		if (row[*leftp] == from) {
 			struct quirc_flood_fill_vars *next_vars;
+			int next_left;
 
 			/* Set up the next context */
 			next_vars = vars + 1;
-			next_vars->left_up = *leftp;
 			next_vars->y = vars->y + direction;
 
 			/* Fill the extent */
 			flood_fill_line(q,
-					next_vars->left_up,
+					*leftp,
 					next_vars->y,
 					from, to,
 					func, user_data,
-					&next_vars->left_up,
+					&next_left,
 					&next_vars->right);
-			next_vars->left_down = next_vars->left_up;
+			next_vars->left_down = next_left;
+			next_vars->left_up = next_left;
 
 			return next_vars;
 		}
@@ -215,17 +216,18 @@ static void flood_fill_seed(struct quirc *q,
 	QUIRC_ASSERT(q->pixels[y0 * q->w + x0] == from);
 
 	struct quirc_flood_fill_vars *next_vars;
+	int next_left;
 
 	/* Set up the first context  */
 	next_vars = stack;
-	next_vars->left_up = x0;
 	next_vars->y = y0;
 
 	/* Fill the extent */
-	flood_fill_line(q, next_vars->left_up, next_vars->y, from, to,
+	flood_fill_line(q, x0, next_vars->y, from, to,
 			func, user_data,
-			&next_vars->left_up, &next_vars->right);
-	next_vars->left_down = next_vars->left_up;
+			&next_left, &next_vars->right);
+	next_vars->left_down = next_left;
+	next_vars->left_up = next_left;
 
 	while (true) {
 		struct quirc_flood_fill_vars * const vars = next_vars;

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -170,14 +170,14 @@ static void flood_fill_seed(struct quirc *q,
 
 	/* Set up the first context  */
 	next_vars = stack;
-	next_vars->x = x0;
+	next_vars->left = x0;
 	next_vars->y = y0;
 
 call:
 	vars = next_vars;
 
 	/* Fill the extent */
-	flood_fill_line(q, vars->x, vars->y, from, to, &vars->left,
+	flood_fill_line(q, vars->left, vars->y, from, to, &vars->left,
 			&vars->right);
 
 	if (func)
@@ -199,7 +199,7 @@ call:
 
 				/* Set up the next context */
 				next_vars = vars + 1;
-				next_vars->x = i;
+				next_vars->left = i;
 				next_vars->y = vars->y - 1;
 				goto call;
 return_from_call1: ;
@@ -217,7 +217,7 @@ return_from_call1: ;
 
 				/* Set up the next context */
 				next_vars = vars + 1;
-				next_vars->x = i;
+				next_vars->left = i;
 				next_vars->y = vars->y + 1;
 				goto call;
 return_from_call2: ;

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -126,6 +126,7 @@ typedef void (*span_func_t)(void *user_data, int y, int left, int right);
 
 static void flood_fill_line(struct quirc *q, int x, int y,
 			    int from, int to,
+			    span_func_t func, void *user_data,
 			    int *leftp, int *rightp)
 {
 	quirc_pixel_t *row;
@@ -152,6 +153,9 @@ static void flood_fill_line(struct quirc *q, int x, int y,
 	/* Return the processed range */
 	*leftp = left;
 	*rightp = right;
+
+	if (func)
+		func(user_data, y, left, right);
 }
 
 static void flood_fill_seed(struct quirc *q,
@@ -187,11 +191,9 @@ call:
 	 */
 
 	/* Fill the extent */
-	flood_fill_line(q, vars->left_up, vars->y, from, to, &vars->left_up,
-			&vars->right);
-
-	if (func)
-		func(user_data, vars->y, vars->left_up, vars->right);
+	flood_fill_line(q, vars->left_up, vars->y, from, to,
+			func, user_data,
+			&vars->left_up, &vars->right);
 
 	if (vars == last_vars) {
 		return;

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -234,6 +234,13 @@ static void flood_fill_seed(struct quirc *q,
 		quirc_pixel_t *row;
 
 		if (vars == last_vars) {
+			/*
+			 * "Stack overflow".
+			 * Just stop and return.
+			 * This can be caused by very complex shapes in
+			 * the image, which is not likely a part of
+			 * a valid QR code anyway.
+			 */
 			break;
 		}
 
@@ -268,6 +275,7 @@ static void flood_fill_seed(struct quirc *q,
 			continue;
 		}
 
+		/* We've done. */
 		break;
 	}
 }

--- a/lib/identify.c
+++ b/lib/identify.c
@@ -133,10 +133,11 @@ static void flood_fill_line(struct quirc *q, int x, int y,
 	int right;
 	int i;
 
+	row = q->pixels + y * q->w;
+	QUIRC_ASSERT(row[x] == from);
+
 	left = x;
 	right = x;
-
-	row = q->pixels + y * q->w;
 
 	while (left > 0 && row[left - 1] == from)
 		left--;
@@ -162,6 +163,9 @@ static void flood_fill_seed(struct quirc *q,
 	const size_t stack_size = q->num_flood_fill_vars;
 	const struct quirc_flood_fill_vars *const last_vars =
 	    &stack[stack_size - 1];
+
+	QUIRC_ASSERT(from != to);
+	QUIRC_ASSERT(q->pixels[y0 * q->w + x0] == from);
 
 	struct quirc_flood_fill_vars *vars;
 	struct quirc_flood_fill_vars *next_vars;

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -50,6 +50,7 @@ int quirc_resize(struct quirc *q, int w, int h)
 	uint8_t		*image  = NULL;
 	quirc_pixel_t	*pixels = NULL;
 	size_t num_vars;
+	size_t vars_byte_size;
 	struct quirc_flood_fill_vars *vars = NULL;
 
 	/*
@@ -100,8 +101,19 @@ int quirc_resize(struct quirc *q, int w, int h)
 	 * - the maximum height of rings would be about 1/3 of the image height.
 	 */
 
-	num_vars = h * 2 / 3;
-	vars = malloc(sizeof(*vars) * num_vars);
+	if ((size_t)h * 2 / 2 != h) {
+		goto fail; /* size_t overflow */
+	}
+	num_vars = (size_t)h * 2 / 3;
+	if (num_vars == 0) {
+		num_vars = 1;
+	}
+
+	vars_byte_size = sizeof(*vars) * num_vars;
+	if (vars_byte_size / sizeof(*vars) != num_vars) {
+		goto fail; /* size_t overflow */
+	}
+	vars = malloc(vars_byte_size);
 	if (!vars)
 		goto fail;
 

--- a/lib/quirc.c
+++ b/lib/quirc.c
@@ -41,6 +41,7 @@ void quirc_destroy(struct quirc *q)
 	   same size, so we need to be careful here to avoid a double free */
 	if (!QUIRC_PIXEL_ALIAS_IMAGE)
 		free(q->pixels);
+	free(q->flood_fill_vars);
 	free(q);
 }
 
@@ -48,6 +49,8 @@ int quirc_resize(struct quirc *q, int w, int h)
 {
 	uint8_t		*image  = NULL;
 	quirc_pixel_t	*pixels = NULL;
+	size_t num_vars;
+	struct quirc_flood_fill_vars *vars = NULL;
 
 	/*
 	 * XXX: w and h should be size_t (or at least unsigned) as negatives
@@ -86,6 +89,22 @@ int quirc_resize(struct quirc *q, int w, int h)
 			goto fail;
 	}
 
+	/*
+	 * alloc the work area for the flood filling logic.
+	 *
+	 * the size was chosen with the following assumptions and observations:
+	 *
+	 * - rings are the regions which requires the biggest work area.
+	 * - they consumes the most when they are rotated by about 45 degree.
+	 *   in that case, the necessary depth is about (2 * height_of_the_ring).
+	 * - the maximum height of rings would be about 1/3 of the image height.
+	 */
+
+	num_vars = h * 2 / 3;
+	vars = malloc(sizeof(*vars) * num_vars);
+	if (!vars)
+		goto fail;
+
 	/* alloc succeeded, update `q` with the new size and buffers */
 	q->w = w;
 	q->h = h;
@@ -95,12 +114,16 @@ int quirc_resize(struct quirc *q, int w, int h)
 		free(q->pixels);
 		q->pixels = pixels;
 	}
+	free(q->flood_fill_vars);
+	q->flood_fill_vars = vars;
+	q->num_flood_fill_vars = num_vars;
 
 	return 0;
 	/* NOTREACHED */
 fail:
 	free(image);
 	free(pixels);
+	free(vars);
 
 	return -1;
 }

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -78,7 +78,6 @@ struct quirc_grid {
 };
 
 struct quirc_flood_fill_vars {
-	int x;
 	int y;
 	int right;
 	int left;

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -17,6 +17,8 @@
 #ifndef QUIRC_INTERNAL_H_
 #define QUIRC_INTERNAL_H_
 
+#include <stdlib.h>
+
 #include "quirc.h"
 
 #define QUIRC_PIXEL_WHITE	0
@@ -75,6 +77,15 @@ struct quirc_grid {
 	double			c[QUIRC_PERSPECTIVE_PARAMS];
 };
 
+struct quirc_flood_fill_vars {
+	int x;
+	int y;
+	int right;
+	int left;
+	int i;
+	int pc; /* caller id */
+};
+
 struct quirc {
 	uint8_t			*image;
 	quirc_pixel_t		*pixels;
@@ -89,6 +100,9 @@ struct quirc {
 
 	int			num_grids;
 	struct quirc_grid	grids[QUIRC_MAX_GRIDS];
+
+	size_t      		num_flood_fill_vars;
+	struct quirc_flood_fill_vars *flood_fill_vars;
 };
 
 /************************************************************************

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -17,9 +17,12 @@
 #ifndef QUIRC_INTERNAL_H_
 #define QUIRC_INTERNAL_H_
 
+#include <assert.h>
 #include <stdlib.h>
 
 #include "quirc.h"
+
+#define QUIRC_ASSERT(a)	assert(a)
 
 #define QUIRC_PIXEL_WHITE	0
 #define QUIRC_PIXEL_BLACK	1

--- a/lib/quirc_internal.h
+++ b/lib/quirc_internal.h
@@ -83,9 +83,8 @@ struct quirc_grid {
 struct quirc_flood_fill_vars {
 	int y;
 	int right;
-	int left;
-	int i;
-	int pc; /* caller id */
+	int left_up;
+	int left_down;
 };
 
 struct quirc {


### PR DESCRIPTION
* Make flood filling logic iterative (vs recursive)
  I basically tried one-to-one conversions here to avoid mistakes.
  probably it has a room for later optimizations.

* Use explicit malloc (vs variables on stack) to allocate the work area.

* Estimate the amount of memory for the work area dynamically
  from the image size, instead of using a constant FLOOD_FILL_MAX_DEPTH,
  which is too big in the most cases.