### PR TITLE
Fix missing SDL_gfx pkg-config check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 
 CC ?= gcc
 PREFIX ?= /usr/local
-SDL_CFLAGS := $(shell pkg-config --cflags sdl 2>&1)
-SDL_LIBS = $(shell pkg-config --libs sdl)
+SDL_CFLAGS := $(shell pkg-config --cflags sdl SDL_gfx 2>&1)
+SDL_LIBS = $(shell pkg-config --libs sdl SDL_gfx)
 
 LIB_VERSION = 1.2
 


### PR DESCRIPTION
In NixOS it's easy to notice this simple discrepancy. I know most people keep SDL_gfx in the same directory as SDL itself, but sometimes that's *not the case*.