### PR TITLE
Ignore pkg-config error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 
 CC ?= gcc
 PREFIX ?= /usr/local
-SDL_CFLAGS := $(shell pkg-config --cflags sdl 2>&1)
-SDL_LIBS = $(shell pkg-config --libs sdl)
+SDL_CFLAGS := $(shell pkg-config --cflags sdl 2> /dev/null)
+SDL_LIBS = $(shell pkg-config --libs sdl 2> /dev/null)
 
 LIB_VERSION = 1.2
 
@@ -43,8 +43,8 @@ DEMO_UTIL_OBJ = \
     demo/dthash.o \
     demo/demoutil.o
 
-OPENCV_CFLAGS := $(shell pkg-config --cflags opencv4 2>&1)
-OPENCV_LIBS = $(shell pkg-config --libs opencv4)
+OPENCV_CFLAGS := $(shell pkg-config --cflags opencv4 2> /dev/null)
+OPENCV_LIBS = $(shell pkg-config --libs opencv4 2> /dev/null)
 QUIRC_CXXFLAGS = $(QUIRC_CFLAGS) $(OPENCV_CFLAGS) --std=c++17
 
 .PHONY: all v4l sdl opencv install uninstall clean


### PR DESCRIPTION
To avoid errors like the following:

```
cc -Ilib -O3 -Wall -fPIC Package sdl was not found in the pkg-config search path. Perhaps you should add the directory containing `sdl.pc' to the PKG_CONFIG_PATH environment variable Package 'sdl' not found -o lib/decode.o -c lib/decode.c
/bin/sh: -c: line 0: unexpected EOF while looking for matching ``'
/bin/sh: -c: line 1: syntax error: unexpected end of file
gmake: *** [Makefile:90: lib/decode.o] Error 2
```

This (at least the SDL part) was neccessary on my environment:

* macOS 15.2
* Xcode 16.2
* pkg-config 2.3.0 (homebrew)
* GNU make 4.4.1 (homebrew)
* opencv 4.11.0 (homebrew)
* no SDL installed